### PR TITLE
Allow building hugo or hugo_extended via an ENV variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,10 +9,12 @@ RUN apk add --no-cache \
     rsync
 
 ENV VERSION 0.49
+ENV VARIATION hugo
+
 RUN mkdir -p /usr/local/src \
     && cd /usr/local/src \
 
-    && curl -L https://github.com/gohugoio/hugo/releases/download/v${VERSION}/hugo_${VERSION}_linux-64bit.tar.gz | tar -xz \
+    && curl -L https://github.com/gohugoio/hugo/releases/download/v${VERSION}/${VARIATION}_${VERSION}_linux-64bit.tar.gz | tar -xz \
     && mv hugo /usr/local/bin/hugo \
 
     && curl -L https://bin.equinox.io/c/dhgbqpS8Bvy/minify-stable-linux-amd64.tgz | tar -xz \

--- a/extended-extras/Dockerfile
+++ b/extended-extras/Dockerfile
@@ -1,0 +1,7 @@
+FROM jguyomard/hugo-builder:0.49-extended
+
+MAINTAINER JG <julien@mangue.eu>
+
+RUN apk add --no-cache \
+    py-setuptools \
+    py-pygments


### PR DESCRIPTION
Hi there,

Thank you for building this repo and documenting it so nicely. I started using it today but I need the `hugo_extended` version for my site.

This is my proposal. If I understand the Docker Cloud docs correctly, you'll be able to automate the creation of `extended` and `extended-extra` tags easily from their admin panel.

Let me know what you think, and/or make any changes you wish.